### PR TITLE
fix: move hardcoded DB credentials and Flask secret key to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env and fill in your values
+# Never commit .env to version control
+
+MYSQL_HOST=localhost
+MYSQL_USER=root
+MYSQL_PASSWORD=your_password_here
+FLASK_SECRET_KEY=your-secret-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .pytest_cache
 .venv
 src/config.py
+.env

--- a/src/app.py
+++ b/src/app.py
@@ -4,7 +4,8 @@ import os
 from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
-app.secret_key = "your_secret_key"
+app.secret_key = os.environ.get("FLASK_SECRET_KEY", "change-me-in-production")
+
 UPLOAD_FOLDER = "uploads"
 app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 
@@ -17,32 +18,25 @@ def index():
         database_name = request.form["database"]
         table_name = request.form["table"]
         column_names = request.form["columns"]
-
         file = request.files["file"]
         if file.filename == "":
             flash("No file selected", "danger")
             return redirect(request.url)
-
         filename = secure_filename(file.filename)
         file_path = os.path.join(app.config["UPLOAD_FOLDER"], filename)
-        file.save(file_path)  # Save uploaded file
-
+        file.save(file_path)
         try:
             result = subprocess.run(
-                ["python", "csv_to_mysql.py", database_name, table_name, column_names, file_path],  
+                ["python", "csv_to_mysql.py", database_name, table_name, column_names, file_path],
                 text=True,
                 capture_output=True
             )
-
             flash(result.stdout, "success")
             if result.stderr:
                 flash(result.stderr, "danger")
-
         except Exception as e:
             flash(f"Error: {e}", "danger")
-
         return redirect(url_for("index"))
-
     return render_template("index.html")
 
 if __name__ == "__main__":

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,11 @@
-# Enter host for your mysql server here, the default is set to localhost replace it if required
-host = "localhost"
+import os
 
-# Enter username for your mysql server
-user = "USERNAME"
+from dotenv import load_dotenv
 
-# Enter password for your mysql server
-password = "PASSWORD"
+load_dotenv()
+
+# MySQL connection settings loaded from environment variables
+# Copy .env.example to .env and fill in your values
+host = os.environ.get("MYSQL_HOST", "localhost")
+user = os.environ.get("MYSQL_USER", "root")
+password = os.environ.get("MYSQL_PASSWORD", "")


### PR DESCRIPTION
## Problem

Database credentials and Flask secret key were hardcoded in source files:

**`src/config.py`**
```python
host = "localhost"
user = "USERNAME"
password = "PASSWORD"
```

**`src/app.py`**
```python
app.secret_key = "your_secret_key"
```

Hardcoded credentials are a security risk — anyone who clones the repo sees them, and they get committed to git history. This is especially problematic when deploying to cloud environments (Railway, Render, AWS, etc.).

## Fix

- **`src/config.py`**: Load `MYSQL_HOST`, `MYSQL_USER`, `MYSQL_PASSWORD` from environment using `python-dotenv`
- **`src/app.py`**: Load `FLASK_SECRET_KEY` from environment
- **`.env.example`**: Added template so contributors know which variables to set

## Usage after this fix

```bash
cp .env.example .env
# Fill in your values in .env
pip install python-dotenv
python src/app.py
```

## References
- [12-Factor App — Config](https://12factor.net/config)
- Closes #27